### PR TITLE
Use Terry's LITImageMagick PDF thumbnail media filter

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -442,6 +442,8 @@ filter.plugins = PDF Text Extractor, PDF Thumbnail, HTML Text Extractor, \
 
 #Assign 'human-understandable' names to each filter
 plugin.named.org.dspace.app.mediafilter.FormatFilter = \
+  org.dspace.app.mediafilter.LitImageThumbnailFilter = LIT Image Thumbnail, \
+  org.dspace.app.mediafilter.LitPdfThumbnailFilter = LIT PDF Thumbnail, \
   org.dspace.app.mediafilter.PDFFilter = PDF Text Extractor, \
   org.dspace.app.mediafilter.XPDF2Thumbnail = PDF Thumbnail, \
   org.dspace.app.mediafilter.HTMLFilter = HTML Text Extractor, \
@@ -459,6 +461,8 @@ filter.org.dspace.app.mediafilter.JPEGFilter.inputFormats = BMP, GIF, JPEG, imag
 filter.org.dspace.app.mediafilter.BrandedPreviewJPEGFilter.inputFormats = BMP, GIF, JPEG, image/png
 filter.org.dspace.app.mediafilter.XPDF2Thumbnail.inputFormats = Adobe PDF
 filter.org.dspace.app.mediafilter.XPDF2Text.inputFormats = Adobe PDF
+filter.org.dspace.app.mediafilter.LitImageThumbnailFilter.inputFormats = BMP, GIF, image/png, JPG, TIFF, JPEG, JPEG 2000
+filter.org.dspace.app.mediafilter.LitPdfThumbnailFilter.inputFormats = Adobe PDF
 
 #Publicly accessible thumbnails of restricted content.
 #List the MediaFilter name's that would get publicly accessible permissions
@@ -474,6 +478,11 @@ filter.org.dspace.app.mediafilter.publicPermission = JPEGFilter, XPDF2Thumbnail
 # are skipped over...these problematic PDFs will never be indexed until
 # memory usage can be decreased in the PDFBox software
 #pdffilter.skiponmemoryexception = true
+
+# LIT / ImageMagick Customizations
+org.dspace.app.mediafilter.LitImageMagickThumbnailFilter.ProcessStarter = /usr/bin/
+org.dspace.app.mediafilter.LitImageMagickThumbnailFilter.ThumbnailWidth = 150
+org.dspace.app.mediafilter.LitImageMagickThumbnailFilter.ThumbnailHeight = 150
 
 
 #### Crosswalk and Packager Plugin Settings ####


### PR DESCRIPTION
We had one-off enabled the GWU LIT ImageMagick media filter for some of our clients
https://github.com/Georgetown-University-Libraries/DSpaceImageMagickThumnails

But with its formal contribution to DSpace/DSpace, we can just merge in this mainstream code into our DSpace, to simplify deployment.

See the Pull Request where this is being discussed:
https://github.com/DSpace/DSpace/pull/597
