### PR TITLE
Fix OAI filter for requiring public ORIGINAL bitstream

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -301,6 +301,19 @@ public class XOAI
         {
             doc.addField("metadata.dc.format.mimetype", f);
         }
+
+        Bundle[] contentBundles = item.getBundles(Constants.CONTENT_BUNDLE_NAME);
+        boolean hasPublicBitstream = false;
+        for (Bundle bundle : contentBundles) {
+            Bitstream[] bitstreams = bundle.getBitstreams();
+            for (Bitstream bitstream : bitstreams) {
+                if (AuthorizeManager.authorizeActionBoolean(_context, bitstream, Constants.READ)) {
+                    hasPublicBitstream = true;
+                    break;
+                }
+            }
+        }
+        doc.addField("item.publicBitstream", hasPublicBitstream);
         
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             MarshallingUtils.writeMetadata(out, ItemUtils.retrieveMetadata(item));

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAuthorizationFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAuthorizationFilter.java
@@ -25,7 +25,9 @@ import org.dspace.handle.HandleManager;
 import org.dspace.xoai.data.DSpaceItem;
 
 /**
- * BitstreamAccessFilter - To determine if there is a publicly accessible bitstream that is accessible
+ * Does this item have full-text available?
+ * i.e. publicly accessible bitstream in the content/original bundle
+ *
  * @author Lyncode Development Team <dspace@lyncode.com>
  */
 public class DSpaceAuthorizationFilter extends DSpaceFilter
@@ -36,7 +38,6 @@ public class DSpaceAuthorizationFilter extends DSpaceFilter
     @Override
     public DatabaseFilterResult getWhere(Context context)
     {
-        log.info("GetWhere");
         List<Object> params = new ArrayList<Object>();
         return new DatabaseFilterResult("EXISTS (SELECT p.action_id FROM "
                 + "resourcepolicy p, " + "bundle2bitstream b, " + "bundle bu, "
@@ -50,7 +51,6 @@ public class DSpaceAuthorizationFilter extends DSpaceFilter
     @Override
     public boolean isShown(DSpaceItem item)
     {
-        log.info("Check if isShown for item: " + item.getIdentifier());
         try
         {
             Context ctx = super.getContext();
@@ -73,8 +73,6 @@ public class DSpaceAuthorizationFilter extends DSpaceFilter
                 }
             }
 
-            //If previous loop didn't return true after it found a readable content bitstream, then nothing readable
-            log.info("NO accessible bitstream in: " + dsitem.getHandle());
             return false;
         }
         catch (SQLException ex)
@@ -91,7 +89,6 @@ public class DSpaceAuthorizationFilter extends DSpaceFilter
     @Override
     public SolrFilterResult getQuery()
     {
-        log.info("SOLR getQuery");
         return new SolrFilterResult("item.public:true AND item.publicBitstream:true");
     }
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DspaceSetSpecFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DspaceSetSpecFilter.java
@@ -43,8 +43,9 @@ public class DspaceSetSpecFilter extends DSpaceFilter
         {
             try
             {
-                DSpaceObject dso = HandleManager.resolveToObject(context,
-                        _setSpec.replace("col_", ""));
+                //&set=col_123456789_2920
+                String handleString = _setSpec.replace("col_", "").replaceFirst("_", "/");
+                DSpaceObject dso = HandleManager.resolveToObject(context, handleString);
                 return new DatabaseFilterResult(
                         "EXISTS (SELECT tmp.* FROM collection2item tmp WHERE tmp.item_id=i.item_id AND collection_id = ?)",
                         dso.getID());
@@ -58,8 +59,8 @@ public class DspaceSetSpecFilter extends DSpaceFilter
         {
             try
             {
-                DSpaceObject dso = HandleManager.resolveToObject(context,
-                        _setSpec.replace("com_", ""));
+                String handleString = _setSpec.replace("com_", "").replaceFirst("_", "/");
+                DSpaceObject dso = HandleManager.resolveToObject(context, handleString);
                 List<Integer> list = XOAIDatabaseManager.getAllSubCollections(
                         context, dso.getID());
                 String subCollections = StringUtils.join(list.iterator(), ",");

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -15,8 +15,7 @@
 
 	<Contexts>
 		<Context baseurl="request">
-            <!-- Open Access (Downloadable) -->
-            <Filter refid="bitstreamaccessFilter"/>
+            <!--<Filter refid="bitstreamaccessFilter"/>-->
 
 			<Format refid="oaidc" />
 			<Format refid="mets" />

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -15,6 +15,9 @@
 
 	<Contexts>
 		<Context baseurl="request">
+            <!-- Open Access (Downloadable) -->
+            <Filter refid="bitstreamaccessFilter"/>
+
 			<Format refid="oaidc" />
 			<Format refid="mets" />
 			<Format refid="xoai" />

--- a/dspace/solr/oai/conf/schema.xml
+++ b/dspace/solr/oai/conf/schema.xml
@@ -147,6 +147,7 @@
    <!-- Item always present information -->
    <field name="item.id" type="int" indexed="true" stored="true" multiValued="false" />
    <field name="item.public" type="boolean" indexed="true" stored="true" multiValued="false" />
+   <field name="item.publicBitstream" type="boolean" indexed="true" stored="true" multiValued="false" />
    <field name="item.handle" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="item.collections" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="item.communities" type="string" indexed="true" stored="true" multiValued="true" />


### PR DESCRIPTION
While trying to enable the bitstreamaccessFilter in XOAI.xml, I encountered some issues.

oai.storage = database, the `DSpaceSetSpecFilter` was failing to grab the handle correctly from the request, needed to convert 123456789_2309 to 123456789/2309.

Also, my interpretation of full-text available for an item is that there is a Bitstream in the ORIGINAL bundle, that is publicly readable. The DB version of that `DSpaceAuthorizationFilter` was correct, but the SOLR version was too loose, and only required that the item be publicly accessible. To fix that, I added a new boolean field to the oai solr schema: `item.publicBitstream`. You'll need to reindex for this to work correctly.

Lastly, to enable to the `bitstreamaccessFilter` for any DSpace instance, ensure that their `dspace/config/crosswalks/oai/xoai.xml` has something like this:

```
<Context baseurl="request">
    <Filter refid="bitstreamaccessFilter"/>
    ...
```
